### PR TITLE
Fix crash without TFC

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -54,7 +54,18 @@ license="All rights reserved"
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[5.0.7.1,)" #mandatory
+    versionRange="[1.18.2-5.0.7.1,)" #mandatory
+    # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
+    ordering="NONE"
+    # Side this dependency is applied on - BOTH, CLIENT or SERVER
+    side="BOTH"
+[[dependencies.tfcambiental]] #optional
+    # the modid of the dependency
+    modId="tfc" #mandatory
+    # Does this dependency have to exist - if not, ordering below must be specified
+    mandatory=true #mandatory
+    # The version range of the dependency
+    versionRange="[2.1.3-beta,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER


### PR DESCRIPTION
**What:**
1. I fixed the crash when there is no TFC, now at the start Forge will write that TFC is needed.
2. I fixed the error of my past PR, since the curios api had a slightly different version, which is why minecraft did not start.

**Additional Info:**
This time I tested everything, it should work :D.

**Potential Compatibility Issues:**
No.